### PR TITLE
Fix scoping data fetches via context project ID

### DIFF
--- a/src/components/ScopingPhase.tsx
+++ b/src/components/ScopingPhase.tsx
@@ -63,7 +63,8 @@ export const ScopingPhase = ({
     handleRetryUseCases,
     handleRetryDatasets,
     handleContinueWithoutUseCase,
-    loadUseCases
+    loadUseCases,
+    hasSearchedUseCases
   } = useScopingPhaseData();
 
   // Check if the scoping phase is already completed from the phases array
@@ -82,17 +83,8 @@ export const ScopingPhase = ({
     updatePhaseStatus
   });
 
-  // Track if search has been attempted
-  const [hasSearchedUseCases, setHasSearchedUseCases] = useState(false);
 
-  // Extract domain from project context on mount
-  useEffect(() => {
-    const searchParams = new URLSearchParams(location.search);
-    const projectId = searchParams.get('projectId');
-
-    // Domain is now determined by the backend
-    setProjectDomain("general_humanitarian");
-  }, []);
+  // Domain is determined by the backend; keep default
 
   // Handle suitability check update
   const handleSuitabilityUpdate = (id: string, answer: 'yes' | 'no' | 'unknown') => {
@@ -149,15 +141,12 @@ export const ScopingPhase = ({
 
   // Handle manual search trigger
   const handleTriggerSearch = () => {
-    setHasSearchedUseCases(true);
     loadUseCases();
   };
 
   // Handle retry search
   const handleRetrySearch = () => {
-    setHasSearchedUseCases(false);
     handleRetryUseCases();
-    setHasSearchedUseCases(true);
   };
 
   // Handle continue without use case

--- a/src/contexts/ProjectContext.tsx
+++ b/src/contexts/ProjectContext.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/types/development-phase";
 
 interface ProjectContextType {
+  projectId: string;
   isLoading: boolean;
   phases: ProjectPhase[];
   setPhases: React.Dispatch<React.SetStateAction<ProjectPhase[]>>;
@@ -412,6 +413,7 @@ export const ProjectProvider: React.FC<{ children: ReactNode }> = ({ children })
 
   return (
     <ProjectContext.Provider value={{
+      projectId,
       isLoading,
       phases, setPhases,
       activePhaseId, setActivePhaseId,

--- a/src/hooks/useDevelopmentPhase.tsx
+++ b/src/hooks/useDevelopmentPhase.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useCallback } from "react";
-import { useLocation } from "react-router-dom";
+import { useProject } from "@/contexts/ProjectContext";
 import { useToast } from "@/hooks/useToast";
 import { 
   DevelopmentPhaseData, 
@@ -28,9 +28,7 @@ export interface DevelopmentPhaseStep {
 
 export const useDevelopmentPhase = () => {
   const { toast } = useToast();
-  const location = useLocation();
-  const searchParams = new URLSearchParams(location.search);
-  const projectId = searchParams.get('projectId');
+  const { projectId } = useProject();
 
   // UI State
   const [currentStep, setCurrentStep] = useState(0);

--- a/src/hooks/useFinalFeasibilityGate.tsx
+++ b/src/hooks/useFinalFeasibilityGate.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useProject } from "@/contexts/ProjectContext";
 import {
   UseCase,
   Dataset,
@@ -35,8 +36,7 @@ export const useFinalFeasibilityGate = ({
   handleCompletePhase,
   resetPhase
 }: FinalFeasibilityGateParams) => {
-  const searchParams = new URLSearchParams(location.search);
-  const projectId = searchParams.get("projectId") || "current";
+  const { projectId } = useProject();
 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);

--- a/src/hooks/useReflectionPhase.tsx
+++ b/src/hooks/useReflectionPhase.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useRef } from "react";
 import { useProject } from "@/contexts/ProjectContext";
-import { useLocation } from "react-router-dom";
 import { useToast } from "@/hooks/useToast";
 import { api } from "@/lib/api";
 
@@ -43,11 +42,9 @@ export const useReflectionPhase = (options: UseReflectionPhaseOptions) => {
   const [isAnalyzing, setIsAnalyzing] = useState(false);
   const [isAdvancing, setIsAdvancing] = useState(false);
   const [ethicalAssessment, setEthicalAssessment] = useState<EthicalAssessment | null>(null);
-  const location = useLocation();
   const { toast } = useToast();
+  const { projectId } = useProject();
 
-  const searchParams = new URLSearchParams(location.search);
-  const projectId = searchParams.get('projectId') || 'current';
 
   const fetchingRef = useRef(false);
   const initializedRef = useRef(false);

--- a/src/hooks/useScopingPhaseData.tsx
+++ b/src/hooks/useScopingPhaseData.tsx
@@ -24,17 +24,15 @@ export const useScopingPhaseData = () => {
   const [feasibilityLevel, setFeasibilityLevel] = useState<'high' | 'medium' | 'low'>('medium'); // Changed from feasibilityRisk
   const [suitabilityScore, setSuitabilityScore] = useState<number>(0);
 
-  const { 
-    constraints, 
-    suitabilityChecks, 
+  const {
+    projectId,
+    constraints,
+    suitabilityChecks,
     selectedUseCase,
     setSelectedUseCase,
     setSelectedDataset,
     scopingActiveStep
   } = useProject();
-
-  const searchParams = new URLSearchParams(location.search);
-  const projectId = searchParams.get('projectId') || 'current';
 
   // Manual function to load use cases
   const loadUseCases = async () => {
@@ -457,6 +455,7 @@ export const useScopingPhaseData = () => {
     setErrorUseCases(null);
     setNoUseCasesFound(false);
     setUseCases([]);
+    setHasSearchedUseCases(true);
     loadUseCases();
   };
 
@@ -478,6 +477,8 @@ export const useScopingPhaseData = () => {
     searchTerm,
     selectedCategory,
     noDatasets,
+    hasSearchedUseCases,
+    hasSearchedDatasets,
     
     // Loading states
     loadingUseCases,

--- a/src/pages/ProjectBlueprint.tsx
+++ b/src/pages/ProjectBlueprint.tsx
@@ -9,7 +9,7 @@ import { ProjectPhaseContent } from "@/components/project-blueprint/ProjectPhase
 import { ProjectPhaseHeader } from "@/components/project-blueprint/ProjectPhaseHeader";
 import { useProject } from "@/contexts/ProjectContext";
 import { api } from "@/lib/api";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 const ProjectBlueprint = () => {
   const { toast } = useToast();
@@ -17,12 +17,9 @@ const ProjectBlueprint = () => {
   const [sidebarOpen, setSidebarOpen] = useState(!isMobile);
   const sidebarRef = useRef<HTMLDivElement>(null);
   const toggleBtnRef = useRef<HTMLButtonElement>(null);
-  const location = useLocation();
   const navigate = useNavigate();
-  
-  // Get projectId from URL query params - improved handling
-  const searchParams = new URLSearchParams(location.search);
-  const projectId = searchParams.get('projectId') || 'current';
+
+  const { projectId } = useProject();
   
   
   // Get activePhaseId from context


### PR DESCRIPTION
## Summary
- expose `projectId` from `ProjectContext`
- consume project id from context across hooks
- return search flags from scoping data hook
- remove duplicate state in `ScopingPhase`
- simplify retry handlers
- use context project id in `ProjectBlueprint`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba71d1f308332b323394c1143175e